### PR TITLE
JwtDecode higher-order component

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,10 @@ Renders a Link which (on clicked) will log out the user
 __options__:
 * `onLogout` - A [`Function`] which fires whenever a Logout action occurs.
 
+### Decode Jwt
+
+A higher-order component that parses the `access_token` for those implementations where the token is a base64 encoded Jwt string. This component decodes it and merges it into the `auth.user` prop of the Redux store
+
 ### Parse Token From Storage
 
 A higher-order component that parses a `token` prop from `localStorage` or `sessionStorage` and pushes it into the Redux store.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "attainia-web-components",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "A collection of Attainia branded web components to be used in an Attainia React.js web application.",
-  "main": "dist/index.js",
+  "main": "index.js",
   "engines": {
-    "node": ">=6"
+    "node": ">= 8.0.0"
   },
   "scripts": {
     "storybook": "start-storybook -p 9001 -c .storybook",
@@ -51,6 +51,7 @@
     "fixed-data-table-2": "0.8.1",
     "history": "4.7.2",
     "hoist-non-react-statics": "2.3.1",
+    "jwt-decode": "2.2.0",
     "pluralize": "7.0.0",
     "prop-types": "15.6.0",
     "ramda": "0.24.1",
@@ -76,8 +77,8 @@
     "uuid": "3.1.0"
   },
   "devDependencies": {
-    "@storybook/addon-info": "^3.2.13",
-    "@storybook/react": "^3.2.13",
+    "@storybook/addon-info": "3.2.13",
+    "@storybook/react": "3.2.13",
     "babel-cli": "6.24.1",
     "babel-eslint": "7.2.3",
     "babel-plugin-add-module-exports": "0.2.1",

--- a/src/components/auth/JwtDecode.container.js
+++ b/src/components/auth/JwtDecode.container.js
@@ -1,0 +1,51 @@
+import {path} from 'ramda'
+import React from 'react'
+import PropTypes from 'prop-types'
+import {connect} from 'react-redux'
+import jwtDecode from 'jwt-decode'
+
+import {withStatics} from '../common/helpers'
+import {decodedJwt} from './actions'
+import JwtDecode from './JwtDecode'
+
+const mapStateToProps = ({auth: {user, parsed_token}}) => ({
+    jwt: path(['token', 'access_token'], user) || parsed_token
+})
+
+const mapDispatchToProps = {decodedJwt}
+
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+    ...stateProps,
+    ...ownProps,
+    async tryDecodeJwt(jwt) {
+        try {
+            const decoded = jwtDecode(jwt)
+            if (decoded) {
+                dispatchProps.decodedJwt(decoded)
+            }
+        } catch (e) {
+            // not a Jwt, but un-comment if it's crucial that it SHOULD be a Jwt
+            // and import/mapDispatchToProps the corresponding handleError creator
+            // dispatchProps.handleError(e)
+        }
+    }
+})
+
+export const withJwtDecode = (DecoratedComponent) => {
+    const WithJwtDecode = ({jwt, tryDecodeJwt, ...passThroughProps}) =>
+        <JwtDecode {...{jwt, tryDecodeJwt}}>
+            <DecoratedComponent {...passThroughProps} />
+        </JwtDecode>
+
+    WithJwtDecode.propTypes = {
+        tryDecodeJwt: PropTypes.func.isRequired,
+        jwt: PropTypes.string
+    }
+
+    return withStatics(
+        connect(mapStateToProps, mapDispatchToProps, mergeProps)(WithJwtDecode),
+        DecoratedComponent
+    )
+}
+
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(JwtDecode)

--- a/src/components/auth/JwtDecode.js
+++ b/src/components/auth/JwtDecode.js
@@ -1,0 +1,28 @@
+import {PureComponent} from 'react'
+import PropTypes from 'prop-types'
+
+class JwtDecode extends PureComponent {
+    componentDidMount() {
+        if (this.props.jwt) {
+            this.props.tryDecodeJwt(this.props.jwt)
+        }
+    }
+
+    componentWillUpdate(nextProps) {
+        if (nextProps.jwt && nextProps.jwt !== this.props.jwt) {
+            this.props.tryDecodeJwt(nextProps.jwt)
+        }
+    }
+
+    render() {
+        return this.props.children
+    }
+}
+
+JwtDecode.propTypes = {
+    children: PropTypes.node,
+    jwt: PropTypes.string,
+    tryDecodeJwt: PropTypes.func.isRequired
+}
+
+export default JwtDecode

--- a/src/components/auth/ParseTokenFromStorage.js
+++ b/src/components/auth/ParseTokenFromStorage.js
@@ -1,16 +1,14 @@
 import {Component} from 'react'
 import PropTypes from 'prop-types'
-import {getAccessTokenFromStorage, removeToken} from './helpers'
+import {getAccessTokenFromStorage, isValidToken, removeToken} from './helpers'
 
 class ParseTokenFromStorage extends Component {
     componentWillMount() {
-        const token = getAccessTokenFromStorage()
-        if (token) {
-            if (token !== '[object Object]') {
-                this.props.parsedToken(token)
-            } else {
-                removeToken()
-            }
+        const token = this.props.tryParseTokenFromStorage()
+        if (this.props.isValidToken(token)) {
+            this.props.parsedToken(token)
+        } else if (this.props.removeToken) {
+             this.props.removeToken(token)
         }
     }
 
@@ -21,7 +19,16 @@ class ParseTokenFromStorage extends Component {
 
 ParseTokenFromStorage.propTypes = {
     children: PropTypes.node,
-    parsedToken: PropTypes.func.isRequired
+    isValidToken: PropTypes.func.isRequired,
+    parsedToken: PropTypes.func.isRequired,
+    removeToken: PropTypes.func,
+    tryParseTokenFromStorage: PropTypes.func.isRequired
+}
+
+ParseTokenFromStorage.defaultProps = {
+    removeToken,
+    isValidToken,
+    tryParseTokenFromStorage: getAccessTokenFromStorage
 }
 
 export default ParseTokenFromStorage

--- a/src/components/auth/TokenInfo.js
+++ b/src/components/auth/TokenInfo.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types'
 
 class TokenInfo extends PureComponent {
     componentDidMount() {
-        if (this.props.token) this.props.tryGetTokenInfo(this.props.token)
+        if (this.props.token) {
+            this.props.tryGetTokenInfo(this.props.token)
+        }
     }
 
     componentWillUpdate(nextProps) {
@@ -19,8 +21,8 @@ class TokenInfo extends PureComponent {
 
 TokenInfo.propTypes = {
     children: PropTypes.node,
-    tryGetTokenInfo: PropTypes.func,
-    token: PropTypes.string
+    token: PropTypes.string,
+    tryGetTokenInfo: PropTypes.func.isRequired
 }
 
 export default TokenInfo

--- a/src/components/auth/Validator.js
+++ b/src/components/auth/Validator.js
@@ -20,9 +20,9 @@ class Validator extends PureComponent {
 }
 
 Validator.propTypes = {
+    children: PropTypes.node,
     token: PropTypes.string,
-    tryValidateToken: PropTypes.func,
-    children: PropTypes.node
+    tryValidateToken: PropTypes.func.isRequired
 }
 
 export default Validator

--- a/src/components/auth/WriteTokenToStorage.container.js
+++ b/src/components/auth/WriteTokenToStorage.container.js
@@ -6,9 +6,8 @@ import {connect} from 'react-redux'
 import {withStatics} from '../common/helpers'
 import WriteTokenToStorage from './WriteTokenToStorage'
 
-const mapStateToProps = (state, ownProps) => ({
-    token: path(['auth', 'user', 'token', 'access_token'], state),
-    storageType: ownProps.storageType || state.auth.storageType
+const mapStateToProps = ({auth: {user}}) => ({
+    token: path(['token', 'access_token'], user)
 })
 
 export const withWriteTokenToStorage = (DecoratedComponent) => {

--- a/src/components/auth/WriteTokenToStorage.js
+++ b/src/components/auth/WriteTokenToStorage.js
@@ -1,20 +1,17 @@
 import {PureComponent} from 'react'
 import PropTypes from 'prop-types'
-import {setToken, getAccessTokenFromStorage} from './helpers'
+import {setToken} from './helpers'
 
 class WriteTokenToStorage extends PureComponent {
     componentDidMount() {
         if (this.props.token) {
-            setToken(this.props.token, this.props.storageType)
+            this.props.tryWriteTokenToStorage(this.props.token, this.props.storageType)
         }
     }
 
     componentWillUpdate(nextProps) {
-        if (nextProps.token) {
-            const existingTokenInStorage = getAccessTokenFromStorage(nextProps.storageType)
-            if (existingTokenInStorage !== nextProps.token) {
-                setToken(this.props.token, this.props.storageType)
-            }
+        if (nextProps.token && nextProps.token !== this.props.token) {
+            this.props.tryWriteTokenToStorage(nextProps.token, nextProps.storageType)
         }
     }
 
@@ -25,8 +22,14 @@ class WriteTokenToStorage extends PureComponent {
 
 WriteTokenToStorage.propTypes = {
     children: PropTypes.node,
+    storageType: PropTypes.oneOf(['local', 'session', 'none']),
     token: PropTypes.string,
-    storageType: PropTypes.oneOf(['local', 'session', 'none'])
+    tryWriteTokenToStorage: PropTypes.func.isRequired
+}
+
+WriteTokenToStorage.defaultProps = {
+    storageType: 'local',
+    tryWriteTokenToStorage: setToken
 }
 
 export default WriteTokenToStorage

--- a/src/components/auth/actions.js
+++ b/src/components/auth/actions.js
@@ -2,6 +2,7 @@ import types from './types'
 
 export const handleError = error => ({error, type: types.ERROR})
 export const clearError = () => ({type: types.CLEAR_ERROR})
+export const decodedJwt = jwt => ({jwt, type: types.DECODED_JWT})
 export const getUserNavMenu = navigation => ({navigation, type: types.GET_USER_NAV_MENU})
 export const passwordHelp = email => ({email, type: types.PASSWORD_HELP})
 export const refresh = refreshTimeout => ({refreshTimeout, type: types.REFRESH})

--- a/src/components/auth/decorators.js
+++ b/src/components/auth/decorators.js
@@ -3,6 +3,7 @@ import {isNotNil} from 'ramda-adjunct'
 import {connectedRouterRedirect} from 'redux-auth-wrapper/history4/redirect'
 import locationHelperBuilder from 'redux-auth-wrapper/history4/locationHelper'
 
+export {withJwtDecode} from './JwtDecode.container'
 export {withTokenParsing} from './ParseTokenFromStorage.container'
 export {withWriteTokenToStorage} from './WriteTokenToStorage.container'
 export {withTokenValidation} from './Validator.container'

--- a/src/components/auth/enhancers.js
+++ b/src/components/auth/enhancers.js
@@ -4,12 +4,14 @@ import {
     withTokenInfo,
     withTokenValidation,
     withTokenParsing,
+    withJwtDecode,
     untilAuthenticatedAndThenRedirectBack
 } from './decorators'
 
 export const withLoginEnhancers = compose(
     withTokenRefresh,
     withTokenInfo,
+    withJwtDecode,
     withTokenValidation,
     withTokenParsing,
     untilAuthenticatedAndThenRedirectBack
@@ -17,6 +19,7 @@ export const withLoginEnhancers = compose(
 
 export const withTokenHelpers = compose(
     withTokenRefresh,
+    withJwtDecode,
     withTokenInfo,
     withTokenValidation,
     withTokenParsing

--- a/src/components/auth/helpers.js
+++ b/src/components/auth/helpers.js
@@ -1,6 +1,11 @@
-import {path} from 'ramda'
+import {path, is, allPass} from 'ramda'
 
 export const isSupportedStorageType = storage => /(local|session)/i.test(storage)
+export const isValidToken = allPass([
+    token => !/\s/.test(token),
+    token => token !== '[object Object]',
+    is(String)
+])
 export const formatBaseUri = uri => (/^https?:\/\//i.test(uri) ? uri : `http://${uri}`)
 export const getAccessToken = props => path(['user', 'token', 'access_token'], props)
 export const getAccessTokenFromStorage = storage => {

--- a/src/components/auth/index.js
+++ b/src/components/auth/index.js
@@ -3,6 +3,8 @@ import AuthErrorContainer from './AuthError.container'
 import AuthError from './AuthError'
 import AuthStatus from './AuthStatus'
 import AuthStatusContainer from './AuthStatus.container'
+import JwtDecode from './JwtDecode'
+import JwtDecodeContainer from './JwtDecode.container'
 import LoginContainer from './Login.container'
 import Login from './Login'
 import LogoutContainer from './Logout.container'
@@ -37,6 +39,8 @@ export {
     AuthError,
     AuthStatus,
     AuthStatusContainer,
+    JwtDecode,
+    JwtDecodeContainer,
     LoginContainer,
     Login,
     LogoutContainer,

--- a/src/components/auth/reducer.js
+++ b/src/components/auth/reducer.js
@@ -5,7 +5,7 @@ import {parseError} from '../common/helpers'
 
 export default (
     state = initialState, {
-        type, app, email, user, error, token, refreshTimeout, navigation
+        type, app, email, user, jwt, error, token, refreshTimeout, navigation
     }
 ) => {
     switch (type) {
@@ -32,6 +32,14 @@ export default (
                 menu: {
                     ...state.menu,
                     navigation: navigation.map(label => ({label}))
+                }
+            }
+        case types.DECODED_JWT:
+            return {
+                ...state,
+                user: {
+                    ...state.user,
+                    ...(jwt || {})
                 }
             }
         case types.LOADING_FINISHED:

--- a/src/components/auth/types.js
+++ b/src/components/auth/types.js
@@ -3,6 +3,7 @@ export default {
     CLEAR_ERROR: 'awc_error_clear',
     CLEAR_REFRESH: 'awc_clear_refresh',
     ERROR: 'awc_error',
+    DECODED_JWT: 'awc_jwt_decoded',
     GET_USER_NAV_MENU: 'awc_get_user_menu',
     LOGIN: 'awc_login',
     LOADING_STARTED: 'awc_started_loading',


### PR DESCRIPTION
Added a new HOC that attempts to decode the token (when it IS a jwt) and merge it into the Redux store's auth.user prop.

Also cleaned up the other HOCs and used `defaultProps` where possible to leverage helper functions (like `localStorage.setItem()` and `localStorage.getItem()`) but still allow the user to override.