### PR TITLE
Added a color lib to use when a nearby color is desired, but the nume…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attainia-web-components",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A collection of Attainia branded web components to be used in an Attainia React.js web application.",
   "main": "index.js",
   "engines": {
@@ -48,6 +48,7 @@
   "dependencies": {
     "axios": "0.16.2",
     "babel-polyfill": "6.26.0",
+    "color": "2.0.1",
     "extensible-duck": "1.3.1",
     "fixed-data-table-2": "0.8.1",
     "history": "4.7.2",

--- a/src/components/common/Form.js
+++ b/src/components/common/Form.js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import {getThemeProp} from './helpers'
 
 export default styled.form`
-    background: ${getThemeProp(['colors', 'grayscale', 'white'], 'lightgray')};
+    background: ${getThemeProp(['colors', 'grayscale', 'lt'], 'lightgray')};
     min-width: ${getThemeProp(['forms', 'smallFormWidth'], '300px')};
     max-width: ${getThemeProp(['forms', 'smallFormWidth'], '300px')};
     margin: 0 auto;

--- a/src/components/common/LinkButton.js
+++ b/src/components/common/LinkButton.js
@@ -5,7 +5,7 @@ import {getThemeProp} from './helpers'
 export default styled(Button)`
     & > a {
         text-decoration: none;
-        color: ${getThemeProp(['grayscale', 'white'], 'white')};
+        color: ${getThemeProp(['colors', 'grayscale', 'white'], 'white')};
         font-size: ${getThemeProp(['fonts', 'fontSize'], '12px')};
     }
 `

--- a/src/components/data-table/DataTable.js
+++ b/src/components/data-table/DataTable.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import {Table, Column, Cell} from 'fixed-data-table-2'
 import 'fixed-data-table-2/dist/fixed-data-table.css'
+import color from 'color'
 
 import ColumnType from './ColumnType'
 import Button from '../common/Button'
@@ -17,6 +18,7 @@ import NumberCell from './NumberCell'
 import InfoIconToolTipTextCell from './InfoIconToolTipTextCell'
 import ImageCell from './ImageCell'
 import IconLinkCell from './IconLinkCell'
+import {getThemeProp} from '../common/helpers'
 
 
 const StyledTable = styled(Table)`
@@ -24,19 +26,29 @@ const StyledTable = styled(Table)`
         height: 100%;
     }
     .fixedDataTableCellLayout_wrap1 span::selection {
-        background-color: #FF2A23;
-        color: #FFFFFF;
+        background-color: ${getThemeProp(['colors', 'primary', 'lt'])};
+        color: white;
     }
     .public_fixedDataTable_bodyRow:hover .public_fixedDataTableCell_main {
-        background-color:  #E4E8E4;
+        background-color: ${props =>
+            color(
+                getThemeProp(['colors', 'grayscale', 'lt'])(props)
+            ).mix(
+                color(getThemeProp(['colors', 'grayscale', 'md'])(props)), 0.1
+            ).hex()
+        };
     }
     .public_fixedDataTableRow_highlighted {
-        background-color: #F0F0F0;
+        background-color: ${getThemeProp(['colors', 'grayscale', 'lt'])};
     }
 `
 
 const TableHeader = styled.div`
-    border: 1px solid #d3d3d3;
+    border: 1px solid ${props =>
+        color(
+            getThemeProp(['colors', 'grayscale', 'lt'])(props)
+        ).darken(0.1).hex()
+    };
     border-bottom-style: none;
     padding: 8px;
 
@@ -46,7 +58,11 @@ const TableHeader = styled.div`
 `
 
 const TableFooter = styled.div`
-    border: 1px solid #d3d3d3;
+    border: 1px solid ${props =>
+        color(
+            getThemeProp(['colors', 'grayscale', 'lt'])(props)
+        ).darken(0.1).hex()
+    };
     border-top-style: none;
     padding: 8px;
     align-items: center;
@@ -59,7 +75,7 @@ const LoadMoreButton = styled(Button)`
     margin-left: auto;
     margin-right: auto;
     padding: 10px 0;
-    background-color: #0072CE;
+    background-color: ${getThemeProp(['colors', 'secondary', 'default'])};
 
     &:disabled {
         background: #C1CDD7;

--- a/src/components/data-table/InfoIconToolTipTextCell.js
+++ b/src/components/data-table/InfoIconToolTipTextCell.js
@@ -5,12 +5,14 @@ import styled from 'styled-components'
 import {Cell} from 'fixed-data-table-2'
 
 import SimpleSvgIcon from '../common/SimpleSvgIcon'
+import {getThemeProp} from '../common/helpers'
 
 
 const InlineImg = styled(SimpleSvgIcon)`
     display: inline;
     margin-right: 16px;
     vertical-align: middle;
+    fill: ${getThemeProp(['colors', 'secondary', 'default'])};
 `
 
 export default class InfoIconToolTipTextCell extends React.PureComponent {
@@ -19,7 +21,6 @@ export default class InfoIconToolTipTextCell extends React.PureComponent {
         return (
             <Cell {...props}>
                 <InlineImg
-                    fill="#0072CE"
                     icon="info"
                     data-tip={toolTip}
                     data-for={'cell-tooltip'}

--- a/src/components/data-table/LinkCell.js
+++ b/src/components/data-table/LinkCell.js
@@ -1,22 +1,25 @@
 import React from 'react'
 import styled from 'styled-components'
+import color from 'color'
 
 import PropTypes from 'prop-types'
 import {Cell} from 'fixed-data-table-2'
+import {getThemeProp} from '../common/helpers'
 
 const StyledAnchor = styled.a`
-    color: #0072CE;
+    color: ${getThemeProp(['colors', 'secondary', 'default'])};
     &:active {
-        color: #328ED7;
+        color: ${getThemeProp(['colors', 'secondary', 'lt'])};
     }
     &:hover {
-        color: #4C9CDC;
+        color: ${props =>
+            color(
+                getThemeProp(['colors', 'secondary', 'lt'])(props)
+            ).lighten(0.1).hex()
+        };
     }
     &:visited {
-        color: #005BA4;
-    }
-    &:disabled {
-
+        color: ${getThemeProp(['colors', 'secondary', 'dk'])};
     }
 `
 

--- a/src/components/data-table/TooltipHeaderCell.js
+++ b/src/components/data-table/TooltipHeaderCell.js
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 import {Cell} from 'fixed-data-table-2'
 
 import {SimpleSvgIcon} from '../common'
+import {getThemeProp} from '../common/helpers'
 
 const FlexDiv = styled.div`
     display: flex;
@@ -33,6 +34,7 @@ const HeaderLink = styled.a`
 `
 
 const SortIcon = styled(SimpleSvgIcon)`
+    fill: ${getThemeProp(['colors', 'secondary', 'default'])};
 `
 
 const flip = ({sortDirection = 'asc'} = {}, needIconName = false) => {
@@ -54,7 +56,7 @@ export default class TooltipHeaderCell extends React.PureComponent {
                         <HeaderLink onClick={() => sortCallback(key, flip(sortData))}>{name}</HeaderLink>
                     </LeftFlexSpan>
                     <RightFlexSpan>
-                        {sortData.columnKey === key ? <SortIcon icon={flip(sortData, true)} fill="#0072CE" /> : null}
+                        {sortData.columnKey === key ? <SortIcon icon={flip(sortData, true)} /> : null}
                     </RightFlexSpan>
                 </FlexDiv>
             </Cell>

--- a/src/components/layout/ContentHeader.js
+++ b/src/components/layout/ContentHeader.js
@@ -30,7 +30,7 @@ const ListHeader = styled.ul`
     list-style: none;
     margin: 0;
     padding: 12px;
-    background: ${getThemeProp(['colors', 'grayscale', 'white'], 'white')};
+    background: ${getThemeProp(['colors', 'grayscale', 'lt'], 'lightgray')};
 
     @supports not (display: grid) {
         & > * {
@@ -59,7 +59,7 @@ const ListHeader = styled.ul`
                 padding-right: 10px; 
             }
             .subtitle {
-                color: ${getThemeProp(['colors', 'grayscale', 'lt'], 'mediumgray')}
+                color: ${getThemeProp(['colors', 'grayscale', 'md'], 'mediumgray')}
             }
         }
     }

--- a/src/components/layout/Footer.js
+++ b/src/components/layout/Footer.js
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import {getThemeProp} from '../common/helpers'
 
 const Footer = styled.footer`
-    background-color: ${getThemeProp(['colors', 'grayscale', 'md'], 'slategrey')};
+    background-color: ${getThemeProp(['colors', 'grayscale', 'dk'], 'darkgray')};
     color: ${getThemeProp(['colors', 'grayscale', 'white'], 'white')};
     padding: 10px 20px;
     text-align: center;

--- a/src/theme.js
+++ b/src/theme.js
@@ -3,21 +3,21 @@ import icons from './icons'
 export const colors = {
     primary: {
         default: '#E10600',
-        lt: '#F0887D',
-        md: '#FF0700',
-        dk: '#E10600'
+        lt: '#FF2A23',
+        md: '#E10600',
+        dk: '#FF0700'
     },
     secondary: {
-        default: '#227FBB',
-        lt: '#60AFFF',
-        md: '#227FBB',
-        dk: '#1B6595'
+        default: '#0072CE',
+        lt: '#328ED7',
+        md: '#0072CE',
+        dk: '#005BA4'
     },
     grayscale: {
-        white: '#ebebeb',
+        white: '#ffffff',
         black: '#1E1E1E',
-        lt: '#cacaca',
-        md: '#464646',
+        lt: '#ebebeb',
+        md: '#cacaca',
         dk: '#333333'
     },
     status: {


### PR DESCRIPTION
It's important to keep our components re-usable, which is one reason we've adopted "theming". We're currently using the `ThemeProvider` from the `styled-components` library (and the `withTheme()` higher-order component, for non styled components) to provide each component with a `theme` prop. Since we've standardized a schema we can expect any component we build to introspect certain props, like `primary`, `secondary`, `grayscale`, etc. And although our schema is following some common numeric scales for those times when much more than `lt`, `md`, and `dk` are needed, it can be a bit overkill to set up such a scale. The compromise being proposed in this PR is to leverage the enormously popular [color](https://www.npmjs.com/package/color) tool to nudge a color in a certain direction. This way we can continue to work off a simple `lt`, `md` and `dk` color palette but also be able to derive nearby colors.