### PR TITLE
eslintrc rule to help catch typos in the defaultProps for a Component

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -127,6 +127,12 @@
     "react/jsx-pascal-case": "error",
     "react/jsx-wrap-multilines": "off",
     "react/require-default-props": "off",
+    "react/default-props-match-prop-types": [
+      "error",
+      {
+        "allowRequiredDefaults": true
+      }
+    ],
     "semi-spacing": "error",
     "semi": [
       "error",


### PR DESCRIPTION
Simple rule change to eslintrc so that misspelled entries in the defaultProps (for any React Component) are caught and corrected

See [this rule](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/default-props-match-prop-types.md) for more detail.