### PR TITLE
These fields aren't in use

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "attainia-web-components",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attainia-web-components",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "description": "A collection of Attainia branded web components to be used in an Attainia React.js web application.",
   "main": "index.js",
   "engines": {

--- a/src/components/auth/mutations.js
+++ b/src/components/auth/mutations.js
@@ -7,13 +7,11 @@ export const LOGIN_USER = gql`
             email
             is_active
             last_login
-            roles
             token {
                 access_token
                 expires_in
                 token_type
                 scope
-                redirect_uris
             }
         }
     }


### PR DESCRIPTION
The `roles` field isn't needed (that information is best parsed from a decoded JWT). The redirect_uris field also isn't being supported any longer.